### PR TITLE
Add proxy support for RDAP and bootstrap HTTP client

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -464,6 +464,17 @@ func RunCLI(args []string, stdout io.Writer, stderr io.Writer, options CLIOption
 		TLSClientConfig: tlsConfig,
 	}
 
+	// If http_proxy is set, use that as the Transport Proxy
+	proxyStr, present := os.LookupEnv("http_proxy")
+	if present {
+		proxyURL, err := url.Parse(proxyStr)
+		if err != nil {
+			printError(stderr, fmt.Sprintf("rdap: Error: invalid proxy URL: %s", proxyURL))
+			return 1
+		}
+		transport.Proxy = http.ProxyURL(proxyURL)
+	}
+
 	// Setup http.RoundTripper for http clients
 	bs.HTTP = &http.Client{
 		Transport: transport,


### PR DESCRIPTION
For issue #18 use a proxy for the RDAP and bootstrap HTTP clients if `http_proxy` is set in the environment

I'm not a terrific golang dev, so let me know if this should be done differently

Thanks!