### PR TITLE
Change the registry accessor functions in bootstrap/client to call c.freshenFromCache with the corresponding RegistryType.

### DIFF
--- a/bootstrap/cache/disk_cache.go
+++ b/bootstrap/cache/disk_cache.go
@@ -7,7 +7,6 @@ package cache
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -98,7 +97,7 @@ func (d *DiskCache) Save(filename string, data []byte) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(d.cacheDirPath(filename), data, 0664)
+	err = os.WriteFile(d.cacheDirPath(filename), data, 0664)
 	if err != nil {
 		return err
 	}
@@ -126,7 +125,7 @@ func (d *DiskCache) Load(filename string) ([]byte, error) {
 	}
 
 	var bytes []byte
-	bytes, err = ioutil.ReadFile(d.cacheDirPath(filename))
+	bytes, err = os.ReadFile(d.cacheDirPath(filename))
 
 	if err != nil {
 		return nil, err

--- a/bootstrap/cache/disk_cache_test.go
+++ b/bootstrap/cache/disk_cache_test.go
@@ -6,7 +6,6 @@ package cache
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,14 +13,14 @@ import (
 )
 
 func TestDiskCache(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test")
+	dir, err := os.MkdirTemp("", "test")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
 
 	rdapDir := filepath.Join(dir, ".openrdap")
-	
+
 	m1 := NewDiskCache()
 	m1.Dir = rdapDir
 
@@ -101,4 +100,3 @@ func TestDiskCache(t *testing.T) {
 		t.Fatalf("loaded2(%v) != asn2(%v)", loaded2, asn2)
 	}
 }
-

--- a/bootstrap/client.go
+++ b/bootstrap/client.go
@@ -14,36 +14,38 @@
 // files.
 //
 // Basic usage:
-//   question := &bootstrap.Question{
-//     RegistryType: bootstrap.DNS,
-//     Query: "example.cz",
-//   }
 //
-//   b := &bootstrap.Client{}
+//	question := &bootstrap.Question{
+//	  RegistryType: bootstrap.DNS,
+//	  Query: "example.cz",
+//	}
 //
-//   var answer *bootstrap.Answer
-//   answer, err := b.Lookup(question)
+//	b := &bootstrap.Client{}
 //
-//   if err == nil {
-//     for _, url := range answer.URLs {
-//       fmt.Println(url)
-//     }
-//   }
+//	var answer *bootstrap.Answer
+//	answer, err := b.Lookup(question)
+//
+//	if err == nil {
+//	  for _, url := range answer.URLs {
+//	    fmt.Println(url)
+//	  }
+//	}
 //
 // Download and list the contents of the DNS Service Registry:
-//   b := &bootstrap.Client{}
 //
-//   // Before you can use a Registry, you need to download it first.
-//   err := b.Download(bootstrap.DNS) // Downloads https://data.iana.org/rdap/dns.json.
+//	b := &bootstrap.Client{}
 //
-//   if err == nil {
-//     var dns *DNSRegistry = b.DNS()
+//	// Before you can use a Registry, you need to download it first.
+//	err := b.Download(bootstrap.DNS) // Downloads https://data.iana.org/rdap/dns.json.
 //
-//     // Print TLDs with RDAP service.
-//     for tld, _ := range dns.File().Entries {
-//       fmt.Println(tld)
-//     }
-//   }
+//	if err == nil {
+//	  var dns *DNSRegistry = b.DNS()
+//
+//	  // Print TLDs with RDAP service.
+//	  for tld, _ := range dns.File().Entries {
+//	    fmt.Println(tld)
+//	  }
+//	}
 //
 // You can configure bootstrap.Client{} with a custom http.Client, base URL
 // (default https://data.iana.org/rdap), and custom cache. bootstrap.Question{}
@@ -68,16 +70,16 @@
 //
 // Disk cache usage:
 //
-//   b := bootstrap.NewClient()
-//   b.Cache = cache.NewDiskCache()
+//	b := &bootstrap.Client{}
+//	b.Cache = cache.NewDiskCache()
 //
-//   dsr := b.DNS()  // Tries to load dns.json from disk cache, doesn't exist yet, so returns nil.
-//   b.Download(bootstrap.DNS) // Downloads dns.json, saves to disk cache.
+//	dsr := b.DNS()  // Tries to load dns.json from disk cache, doesn't exist yet, so returns nil.
+//	b.Download(bootstrap.DNS) // Downloads dns.json, saves to disk cache.
 //
-//   b2 := bootstrap.NewClient()
-//   b2.Cache = cache.NewDiskCache()
+//	b2 := &bootstrap.Client{}
+//	b2.Cache = cache.NewDiskCache()
 //
-//   dsr2 := b.DNS()  // Loads dns.json from disk cache.
+//	dsr2 := b.DNS()  // Loads dns.json from disk cache.
 //
 // This package also implements the experimental Service Provider registry. Due
 // to the experimental nature, no Service Registry file exists on data.iana.org
@@ -92,7 +94,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -236,7 +238,7 @@ func (c *Client) download(ctx context.Context, registry RegistryType) ([]byte, R
 		return nil, nil, fmt.Errorf("Server returned non-200 status code: %s", resp.Status)
 	}
 
-	json, err := ioutil.ReadAll(resp.Body)
+	json, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -357,19 +359,18 @@ func (c *Client) Lookup(question *Question) (*Answer, error) {
 // This function never initiates a network transfer.
 func (c *Client) ASN() *ASNRegistry {
 	c.init()
-	c.freshenFromCache(ServiceProvider)
+	c.freshenFromCache(ASN)
 
 	s, _ := c.registries[ASN].(*ASNRegistry)
 	return s
 }
 
-//
 // DNS returns the current DNS Registry (or nil if the registry file hasn't been Download()ed).
 //
 // This function never initiates a network transfer.
 func (c *Client) DNS() *DNSRegistry {
 	c.init()
-	c.freshenFromCache(ServiceProvider)
+	c.freshenFromCache(DNS)
 
 	s, _ := c.registries[DNS].(*DNSRegistry)
 	return s
@@ -380,7 +381,7 @@ func (c *Client) DNS() *DNSRegistry {
 // This function never initiates a network transfer.
 func (c *Client) IPv4() *NetRegistry {
 	c.init()
-	c.freshenFromCache(ServiceProvider)
+	c.freshenFromCache(IPv4)
 
 	s, _ := c.registries[IPv4].(*NetRegistry)
 	return s
@@ -391,7 +392,7 @@ func (c *Client) IPv4() *NetRegistry {
 // This function never initiates a network transfer.
 func (c *Client) IPv6() *NetRegistry {
 	c.init()
-	c.freshenFromCache(ServiceProvider)
+	c.freshenFromCache(IPv6)
 
 	s, _ := c.registries[IPv6].(*NetRegistry)
 	return s

--- a/cli.go
+++ b/cli.go
@@ -8,10 +8,10 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -421,7 +421,7 @@ func RunCLI(args []string, stdout io.Writer, stderr io.Writer, options CLIOption
 		if options.Sandbox {
 			p12, err = sandbox.LoadFile(p12FilenameAndPassword[0])
 		} else {
-			p12, err = ioutil.ReadFile(p12FilenameAndPassword[0])
+			p12, err = os.ReadFile(p12FilenameAndPassword[0])
 		}
 
 		// Check the file was read correctly.

--- a/client.go
+++ b/client.go
@@ -7,7 +7,7 @@ package rdap
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -275,7 +275,7 @@ func (c *Client) get(rdapReq *Request) *HTTPResponse {
 	}
 
 	defer resp.Body.Close()
-	httpResponse.Body, httpResponse.Error = ioutil.ReadAll(resp.Body)
+	httpResponse.Body, httpResponse.Error = io.ReadAll(resp.Body)
 
 	httpResponse.Duration = time.Since(start)
 

--- a/sandbox/file.go
+++ b/sandbox/file.go
@@ -6,8 +6,8 @@ package sandbox
 
 import (
 	"errors"
-	"io/ioutil"
 	"log"
+	"os"
 	"path"
 	"runtime"
 )
@@ -25,7 +25,7 @@ func LoadFile(filename string) ([]byte, error) {
 		sandboxPath = findPackagePath()
 	}
 
-	body, err := ioutil.ReadFile(path.Join(sandboxPath, filename))
+	body, err := os.ReadFile(path.Join(sandboxPath, filename))
 
 	if err != nil {
 		log.Panic(err)

--- a/test/file.go
+++ b/test/file.go
@@ -5,8 +5,8 @@
 package test
 
 import (
-	"io/ioutil"
 	"log"
+	"os"
 	"path"
 	"runtime"
 )
@@ -20,7 +20,7 @@ func LoadFile(filename string) []byte {
 		testDataPath = findTestDataPath()
 	}
 
-	body, err := ioutil.ReadFile(path.Join(testDataPath, filename))
+	body, err := os.ReadFile(path.Join(testDataPath, filename))
 
 	if err != nil {
 		log.Panic(err)
@@ -39,4 +39,3 @@ func findTestDataPath() string {
 
 	return path.Join(dir, "testdata")
 }
-

--- a/test/http.go
+++ b/test/http.go
@@ -5,7 +5,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 
@@ -59,7 +59,7 @@ func Get(url string) []byte {
 		log.Panic(err)
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 
 	if err != nil {


### PR DESCRIPTION
Change the registry accessor functions in bootstrap/client (ASN(), DNS(), IPv4(), IPv6()) to call c.freshenFromCache with the corresponding RegistryType.

Previously, all types tried to freshen ServiceProvider, which wouldn't have existed if you hadn't accessed that Registry, and wouldn't cause the registry you asked for to be added to the cache. This means the disk cache wasn't used for any type other than ServiceProvider.

Change all uses of ioutil.* to the calls in os.* and io.*.

In the comments for bootstrap/client.go, change "b := bootstrap.NewClient()" to "b := &bootstrap.Client{}" because bootstrap.NewClient() deesn't exist.