### PR TITLE
Rename 'Registrar WHOIS Server' to 'WHOIS Server'

### DIFF
--- a/response.go
+++ b/response.go
@@ -67,8 +67,8 @@ func (r *Response) ToWhoisStyleResponse() *WhoisStyleResponse {
 	// Registry Domain ID
 	w.add("Handle", d.Handle)
 
-	// "Registrar WHOIS Server"
-	w.add("Registrar WHOIS Server", d.Port43)
+	// "WHOIS Server"
+	w.add("WHOIS Server", d.Port43)
 
 	// Events.
 	for _, e := range d.Events {


### PR DESCRIPTION
Hello,

in the whois output, the Port43 value is incorrectly named "Registrar Whois Server," but in the registry response, this is the registry's whois server, not the registrar's.

Here's an example:

**rdap google.xyz --whois**
```
RDAP from Registry:
Domain Name: google.xyz
Handle: D2689447-CNIC
Registrar WHOIS Server: whois.nic.xyz
Creation Date: 2014-05-20T12:04:51.0Z
Expiration Date: 2026-11-26T23:59:59.0Z
Updated Date: 2025-11-11T12:00:30.0Z
Registrar: MarkMonitor, Inc (TLDs)
Registrar IANA ID: 292
Domain Status: client transfer prohibited
Domain Status: client update prohibited
Domain Status: client delete prohibited
Name Server: ns1.google.com
Name Server: ns2.google.com
Name Server: ns3.google.com
Name Server: ns4.google.com


RDAP from Registrar:
Domain Name: google.xyz
Handle: D2689447-CNIC
Registrar WHOIS Server: whois.markmonitor.com
Expiration Date: 2026-11-26T00:00:00.000+00:00
Creation Date: 2014-05-20T12:04:51.000+00:00
Updated Date: 2025-10-25T10:10:19.000+00:00
Registrar: Markmonitor Inc.
Registrar IANA ID: 292
Domain Status: client update prohibited
Domain Status: client transfer prohibited
Domain Status: client delete prohibited
Registrant Name: REDACTED REGISTRANT
Registrant Street: REDACTED FOR PRIVACY
Registrant Locality: REDACTED FOR PRIVACY
Registrant Post Code: REDACTED FOR PRIVACY
Registrant Tel: REDACTED FOR PRIVACY
Registrant Email: REDACTED FOR PRIVACY
Name Server: ns1.google.com
Name Server: ns2.google.com
Name Server: ns3.google.com
Name Server: ns4.google.com
```

This PR renames the label to a generic "WHOIS Server" to resolve the issue.