### PR TITLE
Update version

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	version   = "OpenRDAP v0.9.1"
+	version   = "OpenRDAP v0.10.0"
 	usageText = version + `
 (www.openrdap.org)
 


### PR DESCRIPTION
Current version is v0.10.0 (but the CLI outputs 0.9.1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the CLI version to OpenRDAP v0.10.0.
  * The `--version` output, verbose version message, and usage header now display the updated version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->