### PR TITLE
Derive CLI version from build info + binary release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+on:
+  release:
+    types: [ released ]
+
+concurrency:
+  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
+
+permissions:
+  contents: read
+
+jobs:
+  binary:
+    name: Build and Release Binaries
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Go Environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: '^1.26.0'
+          # Release build off the deploy path; skip the module cache so a
+          # poisoned cache can't corrupt released binaries.
+          cache: false
+
+      - name: Build Binaries
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          mkdir -p builds/compressed
+          go install github.com/mitchellh/gox@latest
+          cd cmd/rdap
+          gox --output "../../builds/rdap-{{.OS}}-{{.Arch}}" -ldflags "-s -w -X github.com/openrdap/rdap.releaseVersion=${TAG}" -osarch 'darwin/amd64 darwin/arm64 linux/386 linux/amd64 linux/arm linux/arm64 freebsd/amd64 freebsd/arm64 windows/386 windows/amd64 windows/arm64'
+          cd ../../builds
+          find . -maxdepth 1 -type f -execdir zip 'compressed/{}.zip' '{}' \;
+
+      - name: Upload Release Assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: builds/compressed/*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cli.go
+++ b/cli.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -26,7 +27,13 @@ import (
 )
 
 var (
-	version   = "OpenRDAP v0.9.1"
+	// releaseVersion is injected into released binaries at build time via
+	// -ldflags "-X github.com/openrdap/rdap.releaseVersion=<tag>". It is empty
+	// for plain `go build` / `go install`, where the version falls back to the
+	// module build info instead.
+	releaseVersion string
+
+	version   = versionString()
 	usageText = version + `
 (www.openrdap.org)
 
@@ -98,6 +105,25 @@ or:
 const (
 	experimentalBootstrapURL = "https://test.rdap.net/rdap"
 )
+
+// versionString resolves the version to display. Released binaries carry the
+// tag injected via ldflags (releaseVersion); a `go install ...@vX.Y.Z` build
+// reports its module version from the build info; everything else is "(dev)".
+func versionString() string {
+	v := releaseVersion
+
+	if v == "" {
+		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+			v = info.Main.Version
+		}
+	}
+
+	if v == "" {
+		v = "(dev)"
+	}
+
+	return "OpenRDAP " + v
+}
 
 // CLIOptions specifies options for the command line client.
 type CLIOptions struct {

--- a/cli_test.go
+++ b/cli_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/openrdap/rdap/test"
@@ -69,6 +70,10 @@ func TestRunCLIGolden(t *testing.T) {
 
 			got := fmt.Sprintf("exit: %d\n--- stdout ---\n%s\n--- stderr ---\n%s",
 				code, stdout.String(), stderr.String())
+
+			// version is derived from build info at runtime, so normalize it to
+			// keep the golden files deterministic across build environments.
+			got = strings.ReplaceAll(got, version, "OpenRDAP vX.Y.Z")
 
 			assertGolden(t, tc.name, got)
 		})

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/jarcoal/httpmock v1.4.1
 	github.com/mitchellh/go-homedir v1.1.0
-	golang.org/x/crypto v0.53.0
+	golang.org/x/crypto v0.54.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
-golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
-golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
+golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
+golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/testdata/cli/no-args.golden
+++ b/testdata/cli/no-args.golden
@@ -4,7 +4,7 @@ exit: 1
 --- stderr ---
 # Error: Query object required, e.g. rdap example.cz
 
-OpenRDAP v0.9.1
+OpenRDAP vX.Y.Z
 (www.openrdap.org)
 
 Usage: rdap [OPTIONS] DOMAIN|IP|ASN|ENTITY|NAMESERVER|RDAP-URL

--- a/testdata/cli/version.golden
+++ b/testdata/cli/version.golden
@@ -1,5 +1,5 @@
 exit: 0
 --- stdout ---
-OpenRDAP v0.9.1
+OpenRDAP vX.Y.Z
 
 --- stderr ---


### PR DESCRIPTION
Fixes #51.

## Problem
The version was a hardcoded `"OpenRDAP v0.9.1"` string that had to be bumped by hand each release. It was missed for v0.10.0, so `rdap -V` reported the wrong version.

## Change
`versionString()` resolves the version in order:
1. `releaseVersion` injected via `-ldflags "-X github.com/openrdap/rdap.releaseVersion=<tag>"` (set for released binaries)
2. module version from `debug.ReadBuildInfo()` so `go install github.com/openrdap/rdap/cmd/rdap@vX.Y.Z` self-reports
3. `(dev)` fallback

New `release.yml` cross-compiles binaries with gox on each release and injects the tag. Added `linux/arm64` (the list previously only had 32-bit `linux/arm`). The CLI golden test normalizes the runtime version to stay deterministic.

## Verification
| Scenario | Output |
|---|---|
| `go install ...@v0.99.0` (real, via local module proxy) | `OpenRDAP v0.99.0` |
| Released zip (ldflags) | `OpenRDAP v0.11.0` |
| Plain `go build` | `OpenRDAP v0.10.0+dirty` |
| `go build -buildvcs=false` | `OpenRDAP (dev)` |

`go test ./...` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated GitHub Actions workflow to build cross-platform release binaries and upload zipped artifacts to each GitHub Release.
* **Changes**
  * Updated the CLI version banner/help text to reflect the actual released version (with development fallback).
* **Tests**
  * Adjusted CLI golden tests to remain deterministic with dynamic version output.
* **Chores**
  * Updated the `golang.org/x/crypto` dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->